### PR TITLE
Replaced el. with $el

### DIFF
--- a/vue-froala.es5.js
+++ b/vue-froala.es5.js
@@ -285,7 +285,7 @@ var vueFroala = (function (Vue) {
         mounted: function mounted() {
             var $el = $(this.$el);
             $el.on('froalaEditor.initialized', function (e, editor) {
-                return el.$editor = editor;
+                return $el.$editor = editor;
             });
             $el.on('froalaEditor.focus', function (e, editor) {
                 return editor.$box.addClass('focus');

--- a/vue-froala.js
+++ b/vue-froala.js
@@ -51,7 +51,7 @@ export default (Vue, Options = {}) => {
         mounted: function() {
             var $el = $(this.$el);
             $el.on('froalaEditor.initialized', function (e, editor) {
-                return el.$editor = editor;
+                return $el.$editor = editor;
             });
             $el.on('froalaEditor.focus', function (e, editor) {
                 return editor.$box.addClass('focus');


### PR DESCRIPTION
Fixes the `Uncaught ReferenceError: el is not defined`-error